### PR TITLE
Handle missing user rows

### DIFF
--- a/app.py
+++ b/app.py
@@ -50,6 +50,9 @@ if not st.session_state.registered:
 
     if is_existing_user(df_users, user_id):
         user_row = get_user_row(df_users, user_id)
+        if user_row is None:
+            st.error("❌ 사용자 정보를 찾을 수 없습니다. 다시 시도해 주세요.")
+            st.stop()
         st.success(f"환영합니다, {user_row['이름']}님!")
         user_name = user_row["이름"]
         user_grade = user_row["학년"]
@@ -85,6 +88,10 @@ if not st.session_state.registered:
 else:
     df_users = get_user_df(ws)
     user_row = get_user_row(df_users, st.session_state.user_id)
+    if user_row is None:
+        st.error("❌ 사용자 정보를 찾을 수 없습니다. 다시 로그인해주세요.")
+        st.session_state.registered = False
+        st.stop()
     user_name = user_row["이름"]
     user_grade = user_row["학년"]
     user_major = user_row["전공"]

--- a/user_manager.py
+++ b/user_manager.py
@@ -16,6 +16,30 @@ def get_user_df(worksheet):
 def is_existing_user(df, user_id):
     return "ID" in df.columns and user_id in df["ID"].astype(str).values
 
+# 특정 사용자의 정보를 포함한 DataFrame 행을 반환
+def get_user_row(df, user_id):
+    """Return the row in ``df`` that matches ``user_id``.
+
+    Parameters
+    ----------
+    df : pandas.DataFrame
+        DataFrame containing user information.
+    user_id : str or int
+        Identifier of the user to look up.
+
+    Returns
+    -------
+    pandas.Series or None
+        The first matching row as a Series if found, otherwise ``None``.
+    """
+    if "ID" not in df.columns:
+        return None
+
+    matches = df[df["ID"].astype(str) == str(user_id)]
+    if not matches.empty:
+        return matches.iloc[0]
+    return None
+
 # 사용자 row 반환
 def register_user(ws, user_id, name, grade, major, style):
     try:


### PR DESCRIPTION
## Summary
- add `get_user_row` to fetch a single user record
- display an error when the row lookup fails during login or later usage

## Testing
- `python -m py_compile app.py user_manager.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684e1b804bd8832ba2eb506a9a030991